### PR TITLE
Fixed implementation of UInt64 message type

### DIFF
--- a/src/rcl/std_msgs/UInt64.h
+++ b/src/rcl/std_msgs/UInt64.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
-#include "ros/msg.h"
+#include "msg.h"
 
 namespace std_msgs
 {
@@ -22,15 +22,14 @@ namespace std_msgs
     virtual int serialize(unsigned char *outbuffer) const
     {
       int offset = 0;
-      union {
-        uint64_t real;
-        uint32_t base;
-      } u_data;
-      u_data.real = this->data;
-      *(outbuffer + offset + 0) = (u_data.base >> (8 * 0)) & 0xFF;
-      *(outbuffer + offset + 1) = (u_data.base >> (8 * 1)) & 0xFF;
-      *(outbuffer + offset + 2) = (u_data.base >> (8 * 2)) & 0xFF;
-      *(outbuffer + offset + 3) = (u_data.base >> (8 * 3)) & 0xFF;
+      *(outbuffer + offset + 0) = (this->data >> (8 * 0)) & 0xFF;
+      *(outbuffer + offset + 1) = (this->data >> (8 * 1)) & 0xFF;
+      *(outbuffer + offset + 2) = (this->data >> (8 * 2)) & 0xFF;
+      *(outbuffer + offset + 3) = (this->data >> (8 * 3)) & 0xFF;
+      *(outbuffer + offset + 4) = (this->data >> (8 * 4)) & 0xFF;
+      *(outbuffer + offset + 5) = (this->data >> (8 * 5)) & 0xFF;
+      *(outbuffer + offset + 6) = (this->data >> (8 * 6)) & 0xFF;
+      *(outbuffer + offset + 7) = (this->data >> (8 * 7)) & 0xFF;
       offset += sizeof(this->data);
       return offset;
     }
@@ -38,18 +37,16 @@ namespace std_msgs
     virtual int deserialize(unsigned char *inbuffer)
     {
       int offset = 0;
-      union {
-        uint64_t real;
-        uint32_t base;
-      } u_data;
-      u_data.base = 0;
-      u_data.base |= ((uint32_t) (*(inbuffer + offset + 0))) << (8 * 0);
-      u_data.base |= ((uint32_t) (*(inbuffer + offset + 1))) << (8 * 1);
-      u_data.base |= ((uint32_t) (*(inbuffer + offset + 2))) << (8 * 2);
-      u_data.base |= ((uint32_t) (*(inbuffer + offset + 3))) << (8 * 3);
-      this->data = u_data.real;
+      this->data =  ((uint64_t) (*(inbuffer + offset)));
+      this->data |= ((uint64_t) (*(inbuffer + offset + 1))) << (8 * 1);
+      this->data |= ((uint64_t) (*(inbuffer + offset + 2))) << (8 * 2);
+      this->data |= ((uint64_t) (*(inbuffer + offset + 3))) << (8 * 3);
+      this->data |= ((uint64_t) (*(inbuffer + offset + 4))) << (8 * 4);
+      this->data |= ((uint64_t) (*(inbuffer + offset + 5))) << (8 * 5);
+      this->data |= ((uint64_t) (*(inbuffer + offset + 6))) << (8 * 6);
+      this->data |= ((uint64_t) (*(inbuffer + offset + 7))) << (8 * 7);
       offset += sizeof(this->data);
-     return offset;
+      return offset;
     }
 
     const char * getType(){ return "std_msgs/UInt64"; };


### PR DESCRIPTION
The UInt64 message type only passed the first 32 bits to the callback function. It appears that UInt64MultiArray has the same issue as UInt64 had.